### PR TITLE
Fix Isaac Lab install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install --upgrade pip
 # Install a CUDA-enabled PyTorch
 pip install -U torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
 # Install the Isaac Lab packages along with Isaac Sim:
-pip install "isaaclab[isaacsim,all]==2.3.0" --extra-index-url https://pypi.nvidia.com
+python -m pip install "isaaclab[isaacsim,all]==2.3.2.post1" --extra-index-url https://pypi.nvidia.com
 ```
 For advanced installation options, refer to [installation guide](https://isaac-sim.github.io/IsaacLab/main/source/setup/installation/index.html).
 


### PR DESCRIPTION
Updates the Isaac Lab installation command from 2.3.0 to 2.3.2.post1 and uses python -m pip. This avoids the flatdict wheel-build failure encountered during installation.