### PR TITLE
Fix mutable default in configclass fallback (no-IsaacLab path)

### DIFF
--- a/source/matterix_sm/matterix_sm/primitive_actions/semantic_action.py
+++ b/source/matterix_sm/matterix_sm/primitive_actions/semantic_action.py
@@ -6,7 +6,7 @@
 """Pure semantic action that triggers semantic state changes instantly."""
 
 import torch
-from dataclasses import MISSING
+from dataclasses import MISSING, field
 
 from .._compat import configclass
 from ..primitive_action import PrimitiveAction, PrimitiveActionCfg
@@ -33,7 +33,7 @@ class SemanticActionCfg(PrimitiveActionCfg):
         )
     """
 
-    agent_assets: str | list[str] = []  # Empty - no agents controlled
+    agent_assets: str | list[str] = field(default_factory=list)  # Empty - no agents controlled
     semantics: list[SemanticInfo] = MISSING  # REQUIRED for SemanticAction
 
     def __post_init__(self):

--- a/source/matterix_sm/matterix_sm/primitive_actions/wait.py
+++ b/source/matterix_sm/matterix_sm/primitive_actions/wait.py
@@ -6,7 +6,7 @@
 """Wait action that holds the current robot state for a specified duration."""
 
 import torch
-from dataclasses import MISSING
+from dataclasses import MISSING, field
 
 from .._compat import configclass
 from ..primitive_action import PrimitiveAction, PrimitiveActionCfg
@@ -36,7 +36,7 @@ class WaitCfg(PrimitiveActionCfg):
         ])
     """
 
-    agent_assets: str | list[str] = []  # Empty - no agents controlled
+    agent_assets: str | list[str] = field(default_factory=list)  # Empty - no agents controlled
     duration: float = MISSING  # Required: seconds to wait
     timeout: float = float("inf")  # Wait always runs to completion — no timeout
 


### PR DESCRIPTION
## Description
`matterix_sm` is supposed to work without Isaac Lab installed, using the fallback `configclass` in `_compat.py`. Right now it crashes on import because two fields use a mutable default (`= []`) instead of `field(default_factory=list)`:

- `primitive_actions/semantic_action.py`
- `primitive_actions/wait.py`

The dataclasses module doesn't allow mutable defaults (Isaac Lab's own `configclass` apparently handles this, but the fallback doesn't). Fixed both to use `default_factory`, matching the pattern already used in `semantic_info.py`. Imported `field` from `dataclasses` in both files.

Tested that `import matterix_sm` works standalone after the fix (`HAS_ISAACLAB=False`).

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `<FULL_PATH_TO_ISAACLAB>/isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there