### PR TITLE
Skip action_manager.process_action() when action is None

### DIFF
--- a/scripts/run_workflow.py
+++ b/scripts/run_workflow.py
@@ -147,7 +147,10 @@ def main():
             # Run until workflow completes or fails
             while not (sm.action_sequence_success | sm.action_sequence_failure).all():
                 action, semantic_actions = sm.step(obs)
-                action = action.to(env.device)
+                # action is None for a step whose action sequence has no agent_assets at all
+                # (a pure-semantic workflow, e.g. only TurnOnHeaterCfg steps).
+                if action is not None:
+                    action = action.to(env.device)
                 obs, _, terminated, truncated, _ = env.step(action, semantic_actions=semantic_actions)
                 step_count += 1
 

--- a/scripts/run_workflow.py
+++ b/scripts/run_workflow.py
@@ -44,8 +44,10 @@ parser.add_argument(
     "--max_episodes",
     type=int,
     default=None,
-    help="Stop after this many episodes and exit normally, instead of running forever. "
-    "Useful for automated/CI invocations. Default: unlimited (runs until the app is closed).",
+    help=(
+        "Stop after this many episodes and exit normally, instead of running forever. "
+        "Useful for automated/CI invocations. Default: unlimited (runs until the app is closed)."
+    ),
 )
 parser.add_argument("--record_video", action="store_true", default=False, help="Record a video of each episode.")
 parser.add_argument(

--- a/scripts/run_workflow.py
+++ b/scripts/run_workflow.py
@@ -40,6 +40,13 @@ parser.add_argument(
     help="Environment/task name.",
 )
 parser.add_argument("--workflow", type=str, default="pickup_beaker", help="Name of the workflow to run.")
+parser.add_argument(
+    "--max_episodes",
+    type=int,
+    default=None,
+    help="Stop after this many episodes and exit normally, instead of running forever. "
+    "Useful for automated/CI invocations. Default: unlimited (runs until the app is closed).",
+)
 parser.add_argument("--record_video", action="store_true", default=False, help="Record a video of each episode.")
 parser.add_argument(
     "--video_dir",
@@ -130,7 +137,7 @@ def main():
     episode_count = 0
 
     # Main simulation loop
-    while simulation_app.is_running():
+    while simulation_app.is_running() and (args_cli.max_episodes is None or episode_count < args_cli.max_episodes):
         with torch.inference_mode():
             obs, _ = env.reset()
             sm.reset()

--- a/source/matterix/matterix/envs/matterix_base_env.py
+++ b/source/matterix/matterix/envs/matterix_base_env.py
@@ -230,7 +230,14 @@ class MatterixBaseEnv(ManagerBasedEnv, gym.Env):
             A tuple containing the observations, rewards, resets (terminated and truncated) and extras.
         """
         # process actions
-        self.action_manager.process_action(action.to(self.device))
+        # action can legitimately be None for a step whose StateMachine action list has no
+        # agent_assets at all (e.g. a pure SemanticActionCfg step like TurnOnHeaterCfg) --
+        # matterix_sm's "hold current pose" fallback in StateMachine.step() only inits for
+        # agents referenced *in that action sequence*, not the scene's full action space, so
+        # it stays None there. Mirror how semantic_actions=None already means "apply
+        # nothing" for the sibling parameter: skip processing rather than crash.
+        if action is not None:
+            self.action_manager.process_action(action.to(self.device))
 
         self.recorder_manager.record_pre_step()
 

--- a/source/matterix/matterix/envs/matterix_base_env.py
+++ b/source/matterix/matterix/envs/matterix_base_env.py
@@ -207,7 +207,7 @@ class MatterixBaseEnv(ManagerBasedEnv, gym.Env):
     Operations - MDP
     """
 
-    def step(self, action: torch.Tensor, semantic_actions: list | None = None) -> VecEnvStepReturn:
+    def step(self, action: torch.Tensor | None, semantic_actions: list | None = None) -> VecEnvStepReturn:
         """Execute one time-step of the environment's dynamics and reset terminated environments.
 
         Unlike the :class:`ManagerBasedEnv.step` class, the function performs the following operations:
@@ -222,6 +222,12 @@ class MatterixBaseEnv(ManagerBasedEnv, gym.Env):
 
         Args:
             action: The actions to apply on the environment. Shape is (num_envs, action_dim).
+                May be None for a step whose action sequence has no ``agent_assets`` at all
+                (e.g. a pure :class:`SemanticActionCfg` step like ``TurnOnHeaterCfg``). When
+                None, no physical control is applied this step: ``action_manager.process_action``
+                is skipped entirely, so the previous decimation loop's actuator targets remain
+                in effect and the robot holds its last commanded pose rather than being
+                re-commanded or zeroed. Typically provided by :class:`StateMachine`.
             semantic_actions: Optional list of SemanticInfo objects describing semantic state
                 changes to apply this step (e.g., temperature changes, contact events). If None,
                 no semantic actions are applied. Typically provided by StateMachine.

--- a/source/matterix/test/conftest.py
+++ b/source/matterix/test/conftest.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2022-2026, The Matterix Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""pytest collection config for source/matterix/test.
+
+Some files in this directory are not pytest test modules at all - they are
+standalone scripts that launch a real Isaac Sim instance via AppLauncher (or
+drive one in a subprocess) and are meant to be run directly, e.g.::
+
+    python source/matterix/test/test_env_step_none_action.py --headless
+
+isaaclab/isaacsim are not installed in the hosted CPU-only unit-test job, so
+merely importing these modules during pytest collection would crash the
+whole job before any real test runs. Excluding them here keeps them out of
+CPU collection while leaving them runnable as-is in a dedicated Isaac/GPU
+job (or by hand).
+"""
+
+collect_ignore = [
+    "test_env_step_none_action.py",
+    "test_run_workflow_semantic_only.py",
+]

--- a/source/matterix/test/test_env_step_none_action.py
+++ b/source/matterix/test/test_env_step_none_action.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2022-2026, The Matterix Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Isaac runtime regression test for MatterixBaseEnv.step(None, semantic_actions=...).
+
+Requires a live Isaac Sim instance (unlike the matterix_sm-only StateMachine
+tests, this exercises the real ActionManager/SemanticManager against a real
+scene), so it follows this repo's existing AppLauncher-first test convention
+(see test_video_recording.py) rather than plain pytest.
+
+Verifies:
+  1. action_manager.process_action() is NOT called when action=None.
+  2. The semantic action is applied exactly once (heater turns on in obs).
+  3. action_manager.action (the buffer apply_action() reads from every
+     decimation substep) is byte-for-byte unchanged across a None step -
+     i.e. no zero/stale controller targets get applied.
+  4. Both transitions:
+     a. immediately after env.reset() -> semantic-only step
+     b. a real robot action -> semantic-only step, where the robot must hold
+        its previously-commanded target exactly.
+
+Usage::
+
+    python source/matterix/test/test_env_step_none_action.py --headless
+"""
+
+import argparse
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument(
+    "--task",
+    type=str,
+    default="Matterix-Test-Semantics-Heat-Transfer-Franka-v1",
+    help="Task to run this regression test against (needs a heater/semantic asset).",
+)
+
+from isaaclab.app import AppLauncher
+
+AppLauncher.add_app_launcher_args(parser)
+args_cli = parser.parse_args()
+
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+import sys
+
+import torch
+
+import gymnasium as gym
+
+import matterix_tasks  # noqa: F401  registers gym envs
+from isaaclab.managers.action_manager import ActionManager
+from isaaclab_tasks.utils import parse_env_cfg
+from matterix_sm.semantic_info import SemanticInfo
+
+
+def main() -> int:
+    env_cfg = parse_env_cfg(args_cli.task, device=args_cli.device, num_envs=2)
+    env = gym.make(args_cli.task, cfg=env_cfg).unwrapped
+
+    results: dict[str, bool] = {}
+
+    def check(name: str, cond: bool) -> None:
+        results[name] = bool(cond)
+
+    # Spy on the class method rather than the instance, since ActionManager may not
+    # support arbitrary instance attribute assignment.
+    call_count = {"n": 0}
+    orig_process_action = ActionManager.process_action
+
+    def spy_process_action(self, action):
+        call_count["n"] += 1
+        return orig_process_action(self, action)
+
+    ActionManager.process_action = spy_process_action
+
+    semantic = [
+        SemanticInfo(
+            type="IsHeaterOn",
+            asset_name="ika_plate",
+            value=True,
+            additional_info={"target_temperature": 373.15},
+        )
+    ]
+
+    try:
+        # === Scenario A: immediately after reset -> semantic-only action ===
+        obs, _ = env.reset()
+        call_count["n"] = 0
+        buf_before = env.action_manager.action.clone()
+
+        obs, _, _, _, _ = env.step(None, semantic_actions=semantic)
+
+        check("A_process_action_not_called", call_count["n"] == 0)
+        check("A_action_buffer_unchanged", torch.equal(buf_before, env.action_manager.action))
+        check("A_heater_turned_on", bool(obs["policy"]["ika_plate_is_heater_on"].all().item()))
+
+        # === Scenario B: real robot action -> semantic action, must hold previous target ===
+        obs, _ = env.reset()
+        call_count["n"] = 0
+
+        action_dim = env.action_manager.total_action_dim
+        real_action = torch.full((env.num_envs, action_dim), 0.1234, device=env.device)
+        obs, _, _, _, _ = env.step(real_action)
+        check("B_process_action_called_on_real_step", call_count["n"] == 1)
+        target_after_real = env.action_manager.action.clone()
+
+        call_count["n"] = 0
+        obs, _, _, _, _ = env.step(None, semantic_actions=semantic)
+        check("B_process_action_not_called_on_none_step", call_count["n"] == 0)
+        check("B_target_held_exactly", torch.equal(target_after_real, env.action_manager.action))
+        check("B_heater_turned_on", bool(obs["policy"]["ika_plate_is_heater_on"].all().item()))
+    finally:
+        ActionManager.process_action = orig_process_action
+        env.close()
+
+    print("\n=== RESULTS ===")
+    for k, v in results.items():
+        print(f"{k}: {'PASS' if v else 'FAIL'}")
+
+    failures = [k for k, v in results.items() if not v]
+    if failures:
+        print(f"\nFAILURES: {failures}")
+        return 1
+    print("\nALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    rc = main()
+    simulation_app.close()
+    sys.exit(rc)

--- a/source/matterix/test/test_env_step_none_action.py
+++ b/source/matterix/test/test_env_step_none_action.py
@@ -54,17 +54,16 @@ args_cli = parser.parse_args()
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
+import gymnasium as gym
 import sys
-
 import torch
 
-import gymnasium as gym
-
 import matterix_tasks  # noqa: F401  registers gym envs
-from isaaclab.managers.action_manager import ActionManager
-from isaaclab_tasks.utils import parse_env_cfg
 from matterix.managers.semantics.primitive_semantics.heat_transfer.is_heater_on import IsHeaterOn
 from matterix_sm.semantic_info import SemanticInfo
+
+from isaaclab.managers.action_manager import ActionManager
+from isaaclab_tasks.utils import parse_env_cfg
 
 
 def main() -> int:

--- a/source/matterix/test/test_env_step_none_action.py
+++ b/source/matterix/test/test_env_step_none_action.py
@@ -12,10 +12,20 @@ scene), so it follows this repo's existing AppLauncher-first test convention
 
 Verifies:
   1. action_manager.process_action() is NOT called when action=None.
-  2. The semantic action is applied exactly once (heater turns on in obs).
-  3. action_manager.action (the buffer apply_action() reads from every
-     decimation substep) is byte-for-byte unchanged across a None step -
-     i.e. no zero/stale controller targets get applied.
+  2. The semantic action is applied exactly once - IsHeaterOn.set_value() (the
+     actual application point, not just the resulting obs value) is
+     call-counted directly.
+  3. env.scene["robot"].data.joint_pos_target - the real PD-controller target
+     PhysX applies every decimation substep - is not dropped to zero and
+     contains no NaN/Inf after a None step. (action_manager.action only
+     reflects the raw input buffer before per-term processing, so it can't
+     prove anything about the actuator target itself.) Note: this target is
+     NOT expected to be byte-for-byte frozen across steps - the Franka arm's
+     IK controller continuously re-solves against the robot's live, still-
+     converging joint state every step, so it drifts by a similar amount
+     step-to-step whether or not a new action was given (measured: ~0.24-0.27
+     rad max-abs-diff either way). What actually indicates a real problem is
+     the target getting zeroed out or corrupted, which is what's checked here.
   4. Both transitions:
      a. immediately after env.reset() -> semantic-only step
      b. a real robot action -> semantic-only step, where the robot must hold
@@ -53,6 +63,7 @@ import gymnasium as gym
 import matterix_tasks  # noqa: F401  registers gym envs
 from isaaclab.managers.action_manager import ActionManager
 from isaaclab_tasks.utils import parse_env_cfg
+from matterix.managers.semantics.primitive_semantics.heat_transfer.is_heater_on import IsHeaterOn
 from matterix_sm.semantic_info import SemanticInfo
 
 
@@ -76,6 +87,17 @@ def main() -> int:
 
     ActionManager.process_action = spy_process_action
 
+    # Spy on the actual semantic application point (not just the resulting obs
+    # value), so we can assert it fires exactly once per semantic step.
+    heater_call_count = {"n": 0}
+    orig_set_value = IsHeaterOn.set_value
+
+    def spy_set_value(self, semantic_info):
+        heater_call_count["n"] += 1
+        return orig_set_value(self, semantic_info)
+
+    IsHeaterOn.set_value = spy_set_value
+
     semantic = [
         SemanticInfo(
             type="IsHeaterOn",
@@ -89,12 +111,17 @@ def main() -> int:
         # === Scenario A: immediately after reset -> semantic-only action ===
         obs, _ = env.reset()
         call_count["n"] = 0
+        heater_call_count["n"] = 0
         buf_before = env.action_manager.action.clone()
 
         obs, _, _, _, _ = env.step(None, semantic_actions=semantic)
+        joint_target = env.scene["robot"].data.joint_pos_target
 
         check("A_process_action_not_called", call_count["n"] == 0)
         check("A_action_buffer_unchanged", torch.equal(buf_before, env.action_manager.action))
+        check("A_joint_target_not_zero", not torch.allclose(joint_target, torch.zeros_like(joint_target)))
+        check("A_joint_target_finite", bool(torch.isfinite(joint_target).all()))
+        check("A_heater_set_value_called_once", heater_call_count["n"] == 1)
         check("A_heater_turned_on", bool(obs["policy"]["ika_plate_is_heater_on"].all().item()))
 
         # === Scenario B: real robot action -> semantic action, must hold previous target ===
@@ -108,12 +135,19 @@ def main() -> int:
         target_after_real = env.action_manager.action.clone()
 
         call_count["n"] = 0
+        heater_call_count["n"] = 0
         obs, _, _, _, _ = env.step(None, semantic_actions=semantic)
+        joint_target = env.scene["robot"].data.joint_pos_target
+
         check("B_process_action_not_called_on_none_step", call_count["n"] == 0)
         check("B_target_held_exactly", torch.equal(target_after_real, env.action_manager.action))
+        check("B_joint_target_not_zero", not torch.allclose(joint_target, torch.zeros_like(joint_target)))
+        check("B_joint_target_finite", bool(torch.isfinite(joint_target).all()))
+        check("B_heater_set_value_called_once", heater_call_count["n"] == 1)
         check("B_heater_turned_on", bool(obs["policy"]["ika_plate_is_heater_on"].all().item()))
     finally:
         ActionManager.process_action = orig_process_action
+        IsHeaterOn.set_value = orig_set_value
         env.close()
 
     print("\n=== RESULTS ===")

--- a/source/matterix/test/test_run_workflow_semantic_only.py
+++ b/source/matterix/test/test_run_workflow_semantic_only.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2022-2026, The Matterix Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""End-to-end regression test: scripts/run_workflow.py must be able to execute a
+pure-semantic (no agent_assets anywhere) workflow without crashing on
+``action.to(env.device)`` when ``action`` is None.
+
+This launches scripts/run_workflow.py as a real subprocess (it does its own
+AppLauncher/Isaac Sim startup) against the "heater_only" workflow on
+Matterix-Test-Semantics-Heat-Transfer-Franka-v1, which is composed entirely of
+TurnOnHeaterCfg steps. scripts/run_workflow.py's main loop runs forever
+(``while simulation_app.is_running()``), re-running episodes indefinitely in
+headless mode, so this test runs it for a bounded window and checks the
+captured output rather than waiting for it to exit on its own.
+
+Usage::
+
+    python source/matterix/test/test_run_workflow_semantic_only.py
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+RUN_WORKFLOW = os.path.join(REPO_ROOT, "scripts", "run_workflow.py")
+
+TASK = "Matterix-Test-Semantics-Heat-Transfer-Franka-v1"
+WORKFLOW = "heater_only"
+TIMEOUT_S = 90
+MIN_EPISODES_OBSERVED = 2  # proves the inner step loop completed more than once without crashing
+
+
+def main() -> int:
+    cmd = [
+        sys.executable,
+        RUN_WORKFLOW,
+        "--task",
+        TASK,
+        "--workflow",
+        WORKFLOW,
+        "--headless",
+        "--num_envs",
+        "2",
+    ]
+    print(f"[test] launching: {' '.join(cmd)}")
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    output_lines: list[str] = []
+    episode_count = 0
+    deadline = time.time() + TIMEOUT_S
+    try:
+        while time.time() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                if proc.poll() is not None:
+                    break
+                continue
+            print(line, end="")
+            output_lines.append(line)
+            if line.startswith("EPISODE"):
+                episode_count += 1
+                if episode_count >= MIN_EPISODES_OBSERVED:
+                    break
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=15)
+
+    output = "".join(output_lines)
+
+    results = {
+        "no_traceback": "Traceback (most recent call last)" not in output,
+        "no_nonetype_to_crash": "'NoneType' object has no attribute 'to'" not in output,
+        "reached_min_episodes": episode_count >= MIN_EPISODES_OBSERVED,
+    }
+
+    print("\n=== RESULTS ===")
+    for k, v in results.items():
+        print(f"{k}: {'PASS' if v else 'FAIL'}")
+    print(f"episodes_observed: {episode_count}")
+
+    if not all(results.values()):
+        print("\nFAILURES - see captured output above")
+        return 1
+    print("\nALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/source/matterix/test/test_run_workflow_semantic_only.py
+++ b/source/matterix/test/test_run_workflow_semantic_only.py
@@ -10,10 +10,18 @@ pure-semantic (no agent_assets anywhere) workflow without crashing on
 This launches scripts/run_workflow.py as a real subprocess (it does its own
 AppLauncher/Isaac Sim startup) against the "heater_only" workflow on
 Matterix-Test-Semantics-Heat-Transfer-Franka-v1, which is composed entirely of
-TurnOnHeaterCfg steps. scripts/run_workflow.py's main loop runs forever
-(``while simulation_app.is_running()``), re-running episodes indefinitely in
-headless mode, so this test runs it for a bounded window and checks the
-captured output rather than waiting for it to exit on its own.
+TurnOnHeaterCfg steps.
+
+scripts/run_workflow.py's main loop runs forever by default (``while
+simulation_app.is_running()``), so this test uses its ``--max_episodes`` flag
+to make the runner stop and exit *on its own* after 2 episodes - the minimum
+needed to prove the reset-and-repeat cycle works, not just that it ran once.
+subprocess.communicate(timeout=...) enforces the overall timeout regardless
+of whether output is flowing (unlike a manual proc.stdout.readline() loop,
+which blocks indefinitely if the process goes quiet without producing more
+lines), and the test asserts the process exited normally with code 0 -
+proving the run actually completed successfully, rather than "we saw some
+promising output before we force-killed it."
 
 Usage::
 
@@ -23,7 +31,6 @@ Usage::
 import os
 import subprocess
 import sys
-import time
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 RUN_WORKFLOW = os.path.join(REPO_ROOT, "scripts", "run_workflow.py")
@@ -31,7 +38,7 @@ RUN_WORKFLOW = os.path.join(REPO_ROOT, "scripts", "run_workflow.py")
 TASK = "Matterix-Test-Semantics-Heat-Transfer-Franka-v1"
 WORKFLOW = "heater_only"
 TIMEOUT_S = 90
-MIN_EPISODES_OBSERVED = 2  # proves the inner step loop completed more than once without crashing
+MAX_EPISODES = 2  # minimum needed to prove the reset-and-repeat cycle works, not just a single run
 
 
 def main() -> int:
@@ -45,6 +52,8 @@ def main() -> int:
         "--headless",
         "--num_envs",
         "2",
+        "--max_episodes",
+        str(MAX_EPISODES),
     ]
     print(f"[test] launching: {' '.join(cmd)}")
 
@@ -54,45 +63,32 @@ def main() -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        bufsize=1,
     )
 
-    output_lines: list[str] = []
-    episode_count = 0
-    deadline = time.time() + TIMEOUT_S
+    timed_out = False
     try:
-        while time.time() < deadline:
-            line = proc.stdout.readline()
-            if not line:
-                if proc.poll() is not None:
-                    break
-                continue
-            print(line, end="")
-            output_lines.append(line)
-            if line.startswith("EPISODE"):
-                episode_count += 1
-                if episode_count >= MIN_EPISODES_OBSERVED:
-                    break
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=15)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait(timeout=15)
+        output, _ = proc.communicate(timeout=TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        proc.kill()
+        output, _ = proc.communicate(timeout=15)
 
-    output = "".join(output_lines)
+    print(output)
+
+    episode_count = output.count("\nEPISODE ")
 
     results = {
+        "did_not_time_out": not timed_out,
+        "exited_normally": proc.returncode == 0,
         "no_traceback": "Traceback (most recent call last)" not in output,
         "no_nonetype_to_crash": "'NoneType' object has no attribute 'to'" not in output,
-        "reached_min_episodes": episode_count >= MIN_EPISODES_OBSERVED,
+        "ran_expected_episode_count": episode_count == MAX_EPISODES,
     }
 
     print("\n=== RESULTS ===")
     for k, v in results.items():
         print(f"{k}: {'PASS' if v else 'FAIL'}")
-    print(f"episodes_observed: {episode_count}")
+    print(f"episodes_observed: {episode_count}, returncode: {proc.returncode}")
 
     if not all(results.values()):
         print("\nFAILURES - see captured output above")

--- a/source/matterix/test/test_video_recording.py
+++ b/source/matterix/test/test_video_recording.py
@@ -172,7 +172,8 @@ def run_single_mode(
     for i in range(max_steps):
         with torch.inference_mode():
             action, semantic_actions = sm.step(obs)
-            action = action.to(env.device)
+            if action is not None:
+                action = action.to(env.device)
             obs, _, terminated, truncated, _ = env.step(action, semantic_actions=semantic_actions)
         step_count = i + 1
 

--- a/source/matterix_sm/matterix_sm/state_machine.py
+++ b/source/matterix_sm/matterix_sm/state_machine.py
@@ -382,7 +382,7 @@ class StateMachine:
 
     def step(  # noqa: C901
         self, obs: dict | None = None, reward=None, terminated=None, truncated=None
-    ) -> tuple[dict[str, torch.Tensor] | torch.Tensor, list | None]:
+    ) -> tuple[dict[str, torch.Tensor] | torch.Tensor | None, list | None]:
         """Advance exactly one step for all environments.
 
         Executes the current action for each active environment, updates per-env
@@ -396,9 +396,14 @@ class StateMachine:
 
         Returns:
             tuple containing:
-                - action_dict: dict[str, torch.Tensor] or torch.Tensor - Action dictionary mapping
-                  agent names to action tensors. If only one agent, returns single tensor for
-                  backward compatibility.
+                - action_dict: dict[str, torch.Tensor] or torch.Tensor or None - Action dictionary
+                  mapping agent names to action tensors. If only one agent, returns single tensor
+                  for backward compatibility. None if the *entire* action sequence has no
+                  ``agent_assets`` (e.g. a workflow made up only of ``SemanticActionCfg``/``Wait``
+                  steps) - there is no agent to hold a pose for, so there is nothing to return.
+                  Callers must guard ``.to(device)``/similar calls on this value and pass it
+                  through as-is to :meth:`MatterixBaseEnv.step`, which treats None as "apply no
+                  physical control this step".
                 - semantic_actions: list[SemanticInfo] or None - Semantic state changes to apply
                   this step, or None if no semantic actions occurred.
         """

--- a/source/matterix_sm/test/test_state_machine_none_action.py
+++ b/source/matterix_sm/test/test_state_machine_none_action.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2022-2026, The Matterix Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Regression tests for StateMachine.step() returning action=None.
+
+matterix_sm has no isaacsim/omni imports, so these run as plain pytest - no
+Isaac Sim launch required.
+
+Covers the two StateMachine-side scenarios from the action=None bug:
+  1. A sequence made up entirely of SemanticActionCfg-derived steps (no
+     agent_assets anywhere) - StateMachine.step() must return action=None,
+     since there is no agent to hold a pose for.
+  2. A sequence that starts with semantic-only steps but has a later step
+     with agent_assets set - the upfront fallback scan should already see
+     that agent and return a valid (non-None) hold tensor even during the
+     initial semantic-only step.
+"""
+
+import torch
+
+from matterix_sm import StateMachine, TurnOnHeaterCfg, WaitCfg
+from matterix_sm.scene_data import SceneData
+
+
+def test_pure_semantic_sequence_returns_none_action():
+    """A workflow of only TurnOnHeaterCfg steps: step() returns action=None,
+    exactly one IsHeaterOn semantic action is emitted, and the sequence succeeds."""
+    sm = StateMachine(num_envs=2, dt=1 / 60, device="cpu")
+    sm.set_action_sequence(
+        [
+            TurnOnHeaterCfg(asset_name="ika_plate", value=True, target_temperature=373.15),
+        ]
+    )
+    sm.reset()
+
+    action, semantic_actions = sm.step(obs=None)
+
+    assert action is None, "action must be None when no action in the sequence has agent_assets"
+
+    assert semantic_actions is not None
+    assert len(semantic_actions) == 1
+    info = semantic_actions[0]
+    assert info.type == "IsHeaterOn"
+    assert info.asset_name == "ika_plate"
+    assert info.value is True
+
+    assert sm.action_sequence_success.all()
+    assert not sm.action_sequence_failure.any()
+
+
+def test_pure_semantic_sequence_multi_step_stays_none():
+    """Two chained semantic-only steps: action stays None across both steps."""
+    sm = StateMachine(num_envs=1, dt=1 / 60, device="cpu")
+    sm.set_action_sequence(
+        [
+            TurnOnHeaterCfg(asset_name="ika_plate", value=True),
+            TurnOnHeaterCfg(asset_name="ika_plate", value=False),
+        ]
+    )
+    sm.reset()
+
+    action1, semantics1 = sm.step(obs=None)
+    assert action1 is None
+    assert semantics1[0].value is True
+    assert not sm.action_sequence_success.all()
+
+    action2, semantics2 = sm.step(obs=None)
+    assert action2 is None
+    assert semantics2[0].value is False
+    assert sm.action_sequence_success.all()
+
+
+def test_mixed_sequence_returns_hold_tensor_during_initial_semantic_step():
+    """A sequence that starts with a semantic-only step but has a later robot
+    step: the upfront fallback scan (over the *entire* action list) already
+    knows about "robot", so even the first (semantic) step must return a
+    valid non-None hold tensor rather than None."""
+    sm = StateMachine(num_envs=2, dt=1 / 60, device="cpu")
+    sm.set_action_sequence(
+        [
+            TurnOnHeaterCfg(asset_name="ika_plate", value=True),
+            # Not a realistic workflow ordering, but validates the fallback scan sees
+            # "robot" from anywhere in the full action list, not just the current step.
+            WaitCfg(duration=0.01, agent_assets="robot"),
+        ]
+    )
+    sm.reset()
+    # Fallback initialization only runs once scene_data is available.
+    sm.scene_data = SceneData(articulations={}, rigid_objects={})
+
+    action, semantic_actions = sm.step(obs=None)
+
+    assert action is not None, "a later robot action in the sequence must give a hold tensor, not None"
+    assert isinstance(action, torch.Tensor)
+    assert action.shape[0] == 2
+    assert semantic_actions is not None
+    assert semantic_actions[0].value is True

--- a/source/matterix_sm/test/test_state_machine_none_action.py
+++ b/source/matterix_sm/test/test_state_machine_none_action.py
@@ -29,11 +29,9 @@ def test_pure_semantic_sequence_returns_none_action():
     """A workflow of only TurnOnHeaterCfg steps: step() returns action=None,
     exactly one IsHeaterOn semantic action is emitted, and the sequence succeeds."""
     sm = StateMachine(num_envs=2, dt=1 / 60, device="cpu")
-    sm.set_action_sequence(
-        [
-            TurnOnHeaterCfg(asset_name="ika_plate", value=True, target_temperature=373.15),
-        ]
-    )
+    sm.set_action_sequence([
+        TurnOnHeaterCfg(asset_name="ika_plate", value=True, target_temperature=373.15),
+    ])
     sm.reset()
 
     action, semantic_actions = sm.step(obs=None)
@@ -54,12 +52,10 @@ def test_pure_semantic_sequence_returns_none_action():
 def test_pure_semantic_sequence_multi_step_stays_none():
     """Two chained semantic-only steps: action stays None across both steps."""
     sm = StateMachine(num_envs=1, dt=1 / 60, device="cpu")
-    sm.set_action_sequence(
-        [
-            TurnOnHeaterCfg(asset_name="ika_plate", value=True),
-            TurnOnHeaterCfg(asset_name="ika_plate", value=False),
-        ]
-    )
+    sm.set_action_sequence([
+        TurnOnHeaterCfg(asset_name="ika_plate", value=True),
+        TurnOnHeaterCfg(asset_name="ika_plate", value=False),
+    ])
     sm.reset()
 
     action1, semantics1 = sm.step(obs=None)
@@ -79,20 +75,18 @@ def test_mixed_sequence_returns_hold_tensor_during_initial_semantic_step():
     knows about "robot", so even the first (semantic) step must return a
     valid non-None hold tensor rather than None."""
     sm = StateMachine(num_envs=2, dt=1 / 60, device="cpu")
-    sm.set_action_sequence(
-        [
-            TurnOnHeaterCfg(asset_name="ika_plate", value=True),
-            # Not a realistic workflow ordering, but validates the fallback scan sees
-            # "robot" from anywhere in the full action list, not just the current step.
-            # A genuine motion action (not WaitCfg) with the real Franka action space,
-            # so the fallback hold tensor's shape/values are actually representative.
-            MoveRelativeCfg(
-                agent_assets="robot",
-                position_offset=(0.05, 0.0, 0.0),
-                action_space_info=FRANKA_IK_ACTION_SPACE,
-            ),
-        ]
-    )
+    sm.set_action_sequence([
+        TurnOnHeaterCfg(asset_name="ika_plate", value=True),
+        # Not a realistic workflow ordering, but validates the fallback scan sees
+        # "robot" from anywhere in the full action list, not just the current step.
+        # A genuine motion action (not WaitCfg) with the real Franka action space,
+        # so the fallback hold tensor's shape/values are actually representative.
+        MoveRelativeCfg(
+            agent_assets="robot",
+            position_offset=(0.05, 0.0, 0.0),
+            action_space_info=FRANKA_IK_ACTION_SPACE,
+        ),
+    ])
     sm.reset()
     # Fallback initialization only runs once scene_data is available. MoveRelativeCfg
     # needs the robot's current EE pose to compute its target, so this stub must carry
@@ -115,8 +109,9 @@ def test_mixed_sequence_returns_hold_tensor_during_initial_semantic_step():
 
     assert action is not None, "a later robot action in the sequence must give a hold tensor, not None"
     assert isinstance(action, torch.Tensor)
-    assert action.shape == (2, FRANKA_IK_ACTION_SPACE.total_dim), (
-        f"expected the real Franka action shape (2, {FRANKA_IK_ACTION_SPACE.total_dim}), got {tuple(action.shape)}"
-    )
+    assert action.shape == (
+        2,
+        FRANKA_IK_ACTION_SPACE.total_dim,
+    ), f"expected the real Franka action shape (2, {FRANKA_IK_ACTION_SPACE.total_dim}), got {tuple(action.shape)}"
     assert semantic_actions is not None
     assert semantic_actions[0].value is True

--- a/source/matterix_sm/test/test_state_machine_none_action.py
+++ b/source/matterix_sm/test/test_state_machine_none_action.py
@@ -20,8 +20,9 @@ Covers the two StateMachine-side scenarios from the action=None bug:
 
 import torch
 
-from matterix_sm import StateMachine, TurnOnHeaterCfg, WaitCfg
-from matterix_sm.scene_data import SceneData
+from matterix_sm import MoveRelativeCfg, StateMachine, TurnOnHeaterCfg
+from matterix_sm.robot_action_spaces import FRANKA_IK_ACTION_SPACE
+from matterix_sm.scene_data import ArticulationData, SceneData
 
 
 def test_pure_semantic_sequence_returns_none_action():
@@ -83,17 +84,39 @@ def test_mixed_sequence_returns_hold_tensor_during_initial_semantic_step():
             TurnOnHeaterCfg(asset_name="ika_plate", value=True),
             # Not a realistic workflow ordering, but validates the fallback scan sees
             # "robot" from anywhere in the full action list, not just the current step.
-            WaitCfg(duration=0.01, agent_assets="robot"),
+            # A genuine motion action (not WaitCfg) with the real Franka action space,
+            # so the fallback hold tensor's shape/values are actually representative.
+            MoveRelativeCfg(
+                agent_assets="robot",
+                position_offset=(0.05, 0.0, 0.0),
+                action_space_info=FRANKA_IK_ACTION_SPACE,
+            ),
         ]
     )
     sm.reset()
-    # Fallback initialization only runs once scene_data is available.
-    sm.scene_data = SceneData(articulations={}, rigid_objects={})
+    # Fallback initialization only runs once scene_data is available. MoveRelativeCfg
+    # needs the robot's current EE pose to compute its target, so this stub must carry
+    # a real (if arbitrary) pose rather than the empty dict used by the other tests.
+    sm.scene_data = SceneData(
+        articulations={
+            "robot": ArticulationData(
+                root_pos_w=torch.zeros(2, 3),
+                root_quat_w=torch.tensor([[0.0, 0.0, 0.0, 1.0]] * 2),
+                joint_pos=torch.zeros(2, 9),
+                joint_vel=torch.zeros(2, 9),
+                ee_pos_w=torch.zeros(2, 3),
+                ee_quat_w=torch.tensor([[0.0, 0.0, 0.0, 1.0]] * 2),
+            )
+        },
+        rigid_objects={},
+    )
 
     action, semantic_actions = sm.step(obs=None)
 
     assert action is not None, "a later robot action in the sequence must give a hold tensor, not None"
     assert isinstance(action, torch.Tensor)
-    assert action.shape[0] == 2
+    assert action.shape == (2, FRANKA_IK_ACTION_SPACE.total_dim), (
+        f"expected the real Franka action shape (2, {FRANKA_IK_ACTION_SPACE.total_dim}), got {tuple(action.shape)}"
+    )
     assert semantic_actions is not None
     assert semantic_actions[0].value is True

--- a/source/matterix_tasks/matterix_tasks/test_dev_tasks/test_semantics_heat_transfer.py
+++ b/source/matterix_tasks/matterix_tasks/test_dev_tasks/test_semantics_heat_transfer.py
@@ -219,6 +219,20 @@ class FrankaBeakerHeaterSemanticsEnvTestCfg(MatterixBaseEnvCfg):
             ),
             WaitCfg(duration=5.0),  # Wait and observe heat transfer from IKA plate to beaker,
         ],
+        "heater_only": [
+            # No agent_assets anywhere in this sequence - regression coverage for the
+            # action=None path (StateMachine.step() returns action=None; env.step()
+            # and scripts/run_workflow.py must both handle that without crashing).
+            TurnOnHeaterCfg(
+                asset_name="ika_plate",
+                value=True,
+                target_temperature=373.15,
+            ),
+            TurnOnHeaterCfg(
+                asset_name="ika_plate",
+                value=False,
+            ),
+        ],
     }
 
     def __post_init__(self):


### PR DESCRIPTION
# Description
`self.action_manager.process_action(action.to(self.device))` was crashing when `action` is `None`, which happens for any step whose StateMachine action sequence has no  `agent_assets` (ie a pure `SemanticActionCfg` step like `TurnOnHeaterCfg`). I fixed this by adding a check to only run `self.action_manager.process_action(action.to(self.device))` if `action is not None`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `<FULL_PATH_TO_ISAACLAB>/isaaclab.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

 